### PR TITLE
Add warnings to compilation tests

### DIFF
--- a/src/6a-generate.c
+++ b/src/6a-generate.c
@@ -849,7 +849,7 @@ void generate(struct generator *gen)
         output_line(out, "#define NUMBER_TOKEN_DATA(...)");
         output_line(out, "#define IF_NUMBER_TOKEN(...) if (0) { /* no number tokens */  }");
     } else {
-        output_line(out, "#define NUMBER_TOKEN_DATA(name) double name");
+        output_line(out, "#define NUMBER_TOKEN_DATA(name) double name = 0");
         output_line(out, "#define IF_NUMBER_TOKEN(cond, ...) if (cond) __VA_ARGS__");
     }
     if (!has_string_token)

--- a/src/test.c
+++ b/src/test.c
@@ -17,6 +17,7 @@ void begin_test_compilation(struct test_compilation *t)
     int i = 1;
     t->args[i++] = "-pedantic";
     t->args[i++] = "-Wall";
+    t->args[i++] = "-Wconditional-uninitialized";
     t->args[i++] = "-Wno-unused-function"; // Modern compilers all understand DCE and functions/variables
     t->args[i++] = "-Wno-unused-variable"; // that go unused for some grammars may be necessary for others
     t->args[i++] = "-x";

--- a/src/test.c
+++ b/src/test.c
@@ -14,12 +14,17 @@ void begin_test_compilation(struct test_compilation *t)
     t->args[0] = getenv("CC");
     if (!t->args[0])
         t->args[0] = "cc";
-    t->args[1] = "-x";
-    t->args[2] = "c";
-    t->args[3] = "-";
-    t->args[4] = "-o";
-    t->args[5] = t->executable_filename;
-    t->args[6] = 0;
+    int i = 1;
+    t->args[i++] = "-pedantic";
+    t->args[i++] = "-Wall";
+    t->args[i++] = "-Wno-missing-braces";
+    t->args[i++] = "-Wno-overlength-strings";
+    t->args[i++] = "-x";
+    t->args[i++] = "c";
+    t->args[i++] = "-";
+    t->args[i++] = "-o";
+    t->args[i++] = t->executable_filename;
+    t->args[i++] = 0;
     t->program = t->args[0];
     spawn_child(t);
     fprintf(t->file, "#define OWL_PARSER_IMPLEMENTATION\n");

--- a/src/test.c
+++ b/src/test.c
@@ -17,8 +17,8 @@ void begin_test_compilation(struct test_compilation *t)
     int i = 1;
     t->args[i++] = "-pedantic";
     t->args[i++] = "-Wall";
-    t->args[i++] = "-Wno-missing-braces";
-    t->args[i++] = "-Wno-overlength-strings";
+    t->args[i++] = "-Wno-unused-function"; // Modern compilers all understand DCE and functions/variables
+    t->args[i++] = "-Wno-unused-variable"; // that go unused for some grammars may be necessary for others
     t->args[i++] = "-x";
     t->args[i++] = "c";
     t->args[i++] = "-";


### PR DESCRIPTION
When integrating a generated parser in my own project (with its own compiler flags) I noticed a `conditional-uninitialized` warning, which is sometimes evidence of a bug. Adding `-Wconditional-uninitialized -pedantic -Wall` to the test flags resulted in the following warnings:

```
$ git diff --stat --exit-code test/results | grep test | awk '{ print $1; }' | xargs cat | grep -- "-W" | awk '{print $NF}' | sort | uniq -c | sort -rn
  57 [-Wunused-function]
  43 [-Wunused-variable]
   8 [-Wconditional-uninitialized]
```

`-Wunused-*` isn't necessarily something a parser generator wants to worry about (all compilers nowadays have a DCE pass in the optimizer anyway) so I added exceptions for those and fixed the `conditional-uninitialized` warning with an initial value in `NUMBER_TOKEN_DATA`.